### PR TITLE
Do not install obsoleted backup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ install-profiled-ini: ini/10.meego_default.ini
 	install -m755 -d $(ROOT)$(ETCDIR)/
 	install -m644 ini/10.meego_default.ini $(ROOT)$(ETCDIR)/10.meego_default.ini
 
-install-profiled:: $(addprefix install-profiled-, bin backup-config backupfw-config appkiller ini)
+install-profiled:: $(addprefix install-profiled-, bin ini)
 ifeq ($(USE_SYSTEM_BUS),y)
 	install -m755 -d $(ROOT)$(PREFIX)/share/dbus-1/system-services
 	install -m644 profiled.system.service \

--- a/rpm/profiled.spec
+++ b/rpm/profiled.spec
@@ -114,13 +114,9 @@ rm %{buildroot}/%{_libdir}/libprofile.a
 %files
 %defattr(-,root,root,-)
 # >> files
-%config(noreplace) %{_sysconfdir}/osso-backup/applications/profiled.conf
-%{_sysconfdir}/osso-cud-scripts/profiled.sh
-%{_sysconfdir}/osso-rfs-scripts/profiled.sh
 %dir %{_sysconfdir}/profiled
 %{_bindir}/%{name}
 %{_libdir}/libprofile.so.*
-%{_datadir}/backup-framework/applications/profiled.conf
 %{_datadir}/dbus-1/services/profiled.service
 # << files
 


### PR DESCRIPTION
Backup scripts are for Fremantle and Harmattan, we don't need to install those on Nemo.
